### PR TITLE
Java Demo Application related changes.

### DIFF
--- a/fusion-client-demo/src/main/java/com/dmg/fusion/FusionClientDemo.java
+++ b/fusion-client-demo/src/main/java/com/dmg/fusion/FusionClientDemo.java
@@ -16,6 +16,7 @@ import java.text.SimpleDateFormat;
 import java.time.Instant;
 import java.util.Arrays;
 import java.util.Date;
+import java.util.HashMap;
 import java.util.Optional;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
@@ -23,12 +24,17 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
+import java.sql.Timestamp;
+import java.util.List;
+import java.util.Map;
 
 import javax.crypto.BadPaddingException;
 import javax.crypto.IllegalBlockSizeException;
 import javax.crypto.NoSuchPaddingException;
 import javax.naming.ConfigurationException;
 import javax.websocket.DeploymentException;
+
+import org.w3c.dom.events.Event;
 
 import au.com.dmg.fusion.MessageHeader;
 import au.com.dmg.fusion.client.FusionClient;
@@ -47,6 +53,8 @@ import au.com.dmg.fusion.data.UnitOfMeasure;
 import au.com.dmg.fusion.exception.NotConnectedException;
 import au.com.dmg.fusion.request.SaleTerminalData;
 import au.com.dmg.fusion.request.SaleToPOIRequest;
+import au.com.dmg.fusion.request.aborttransactionrequest.AbortTransactionRequest;
+import au.com.dmg.fusion.request.displayrequest.DisplayRequest;
 import au.com.dmg.fusion.request.loginrequest.LoginRequest;
 import au.com.dmg.fusion.request.loginrequest.SaleSoftware;
 import au.com.dmg.fusion.request.paymentrequest.AmountsReq;
@@ -62,15 +70,22 @@ import au.com.dmg.fusion.request.transactionstatusrequest.TransactionStatusReque
 import au.com.dmg.fusion.response.Response;
 import au.com.dmg.fusion.response.ResponseResult;
 import au.com.dmg.fusion.response.SaleToPOIResponse;
+import au.com.dmg.fusion.response.paymentresponse.PaymentResponse;
 import au.com.dmg.fusion.securitytrailer.SecurityTrailer;
 import au.com.dmg.fusion.util.MessageHeaderUtil;
 import au.com.dmg.fusion.util.SecurityTrailerUtil;
+import au.com.dmg.fusion.response.DisplayResponse;
+import au.com.dmg.fusion.response.EventNotification;
+import au.com.dmg.fusion.response.OutputResult;
+import au.com.dmg.fusion.SaleToPOI;
+import au.com.dmg.fusion.request.displayrequest.DisplayRequest;
 
 public class FusionClientDemo {
 
 	public static final String SALE_ID;
 	public static final String POI_ID;
 	private static final FusionClient fusionClient = new FusionClient();
+	private static final SimpleDateFormat sdf = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSSXXX");
 
 	static {
 		initConfig();
@@ -86,35 +101,39 @@ public class FusionClientDemo {
 			doPayment();
 
 			fusionClient.disconnect();
-			System.out.println("Disconnected from websocket server");
+			log("Disconnected from websocket server.");
 		} catch (ConfigurationException e) {
-			System.out.println(e);
+			log(String.format("ConfigurationException: %s", e.toString()));
 		} catch (KeyManagementException | NoSuchAlgorithmException | DeploymentException | IOException
 				| URISyntaxException | CertificateException | KeyStoreException e) {
-			System.out.println(e);
+			log(String.format("Exception: %s", e.toString()));
 		}
 	}
-	
+
 	private static void initConfig() {
+		log("Current Working Directory = " + System.getProperty("user.dir"));
 		String certificateLocation = "src/main/resources/root.crt"; // test environment only - replace for production
-		String serverDomain = "wss://www.cloudposintegration.io/nexodev"; // test environment only - replace for production
+		String serverDomain = "wss://www.cloudposintegration.io/nexodev"; // test environment only - replace for
+																			// production
 		String socketProtocol = "TLSv1.2";
 
-		String kekValue = "44DACB2A22A4A752ADC1BBFFE6CEFB589451E0FFD83F8B21"; // test environment only - replace for production
+		String kekValue = "44DACB2A22A4A752ADC1BBFFE6CEFB589451E0FFD83F8B21"; // test environment only - replace for
+																				// production
 		String keyIdentifier = "SpecV2TestMACKey"; // test environment only - replace for production
 		String keyVersion = "20191122164326.594"; // test environment only - replace for production
 
 		String providerIdentification = "Company A"; // test environment only - replace for production
 		String applicationName = "POS Retail"; // test environment only - replace for production
 		String softwareVersion = "01.00.00"; // test environment only - replace for production
-		String certificationCode = "98cf9dfc-0db7-4a92-8b8cb66d4d2d7169"; // test environment only - replace for production
+		String certificationCode = "98cf9dfc-0db7-4a92-8b8cb66d4d2d7169"; // test environment only - replace for
+																			// production
 
 		try {
 			FusionClientConfig.init(certificateLocation, serverDomain, socketProtocol);
 			KEKConfig.init(kekValue, keyIdentifier, keyVersion);
 			SaleSystemConfig.init(providerIdentification, applicationName, softwareVersion, certificationCode);
 		} catch (ConfigurationException e) {
-			System.out.println(e); // Ensure all config fields have values
+			log(String.format("ConfigurationException: %s", e.toString())); // Ensure all config fields have values
 		}
 	}
 
@@ -123,7 +142,7 @@ public class FusionClientDemo {
 		try {
 			loginRequest = buildLoginRequest();
 
-			System.out.println("Sending message to websocket server: " + "\n" + loginRequest);
+			log("Sending message to websocket server: " + "\n" + loginRequest);
 			fusionClient.sendMessage(loginRequest);
 
 			boolean waitingForResponse = true;
@@ -133,12 +152,12 @@ public class FusionClientDemo {
 				try {
 					optResponse = Optional.ofNullable(fusionClient.inQueueResponse.poll(1, TimeUnit.SECONDS));
 				} catch (InterruptedException e) {
-					System.out.println(e);
+					log(String.format("InterruptedException: %s", e.toString()));
 				}
 
 				if (optResponse.isPresent()) {
 					SaleToPOIResponse response = optResponse.get();
-					System.out.println(response.toJson());
+					log(String.format("Response(JSON): %s", response.toJson()));
 
 					boolean serviceIDMatchesRequest = response.getMessageHeader() != null //
 							&& response.getMessageHeader().getServiceID()
@@ -149,10 +168,10 @@ public class FusionClientDemo {
 						Response responseBody = response.getLoginResponse().getResponse();
 
 						if (responseBody.getResult() != null) {
-							System.out.println(String.format("Login Result: %s ", responseBody.getResult()));
+							log(String.format("Login Result: %s ", responseBody.getResult()));
 
 							if (responseBody.getResult() != ResponseResult.Success) {
-								System.out.println(String.format("Error Condition: %s, Additional Response: %s",
+								log(String.format("Error Condition: %s, Additional Response: %s",
 										responseBody.getErrorCondition(), responseBody.getAdditionalResponse()));
 							}
 						}
@@ -161,9 +180,9 @@ public class FusionClientDemo {
 				}
 			}
 		} catch (ConfigurationException e) {
-			System.out.println(e);
+			log(String.format("ConfigurationException: %s", e.toString()));
 		} catch (NotConnectedException e) {
-			System.out.println(e);
+			log(String.format("NotConnectedException: %s", e.toString()));
 		}
 	}
 
@@ -177,24 +196,26 @@ public class FusionClientDemo {
 					Optional<SaleToPOIRequest> optMessageRequest;
 					try {
 						optMessageRequest = Optional.ofNullable(fusionClient.inQueueRequest.poll(1, TimeUnit.SECONDS));
-						optMessageRequest.ifPresent(o -> System.out.println(o.toString()));
+						optMessageRequest.ifPresent(o -> handleRequestMessage(o));
 					} catch (InterruptedException e) {
-						System.out.println("Stop polling for display requests...");
+						log("Stop polling for display requests...");
 						break;
 					}
 				}
 			}
 		});
 
-		ExecutorService executor = Executors.newSingleThreadExecutor();
-		Future<Void> payment = executor.submit(() -> {
-			SaleToPOIRequest paymentRequest = null;
+		String abortReason = "";
 
+		ExecutorService executor = Executors.newSingleThreadExecutor();
+		Future<Boolean> payment = executor.submit(() -> {
+			SaleToPOIRequest paymentRequest = null;
+			boolean gotValidResponse = false;
 			// Payment request
 			try {
 				paymentRequest = buildPaymentRequest(serviceID);
 
-				System.out.println("Sending message to websocket server: " + "\n" + paymentRequest);
+				log("Sending message to websocket server: " + "\n" + paymentRequest);
 				fusionClient.sendMessage(paymentRequest);
 
 				boolean waitingForResponse = true;
@@ -205,101 +226,171 @@ public class FusionClientDemo {
 							.ofNullable(fusionClient.inQueueResponse.poll(1, TimeUnit.SECONDS));
 
 					if (optResponse.isPresent()) {
-						SaleToPOIResponse response = optResponse.get();
-						System.out.println(response.toJson());
+						Map<String, Boolean> responseResult = handleResponseMessage(paymentRequest, optResponse.get());
 
-						boolean serviceIDMatchesRequest = response.getMessageHeader() != null //
-								&& response.getMessageHeader().getServiceID()
-										.equalsIgnoreCase(paymentRequest.getMessageHeader().getServiceID());
+						if (responseResult.containsKey("WaitingForAnotherResponse"))
+							waitingForResponse = responseResult.get("WaitingForAnotherResponse");
+						else
+							waitingForResponse = true;
 
-						if (serviceIDMatchesRequest && response.getPaymentResponse().getResponse() != null) {
-							boolean saleTransactionIDMatchesRequest = response.getPaymentResponse()
-									.getSaleData() != null
-									&& response.getPaymentResponse().getSaleData().getSaleTransactionID() != null
-									&& response.getPaymentResponse().getSaleData().getSaleTransactionID()
-											.getTransactionID().equals(paymentRequest.getPaymentRequest().getSaleData()
-													.getSaleTransactionID().getTransactionID());
-
-							if (!saleTransactionIDMatchesRequest) {
-								if (response.getPaymentResponse().getSaleData() == null) {
-									System.out.println("Sale ID missing from request");
-								} else {
-									System.out.println("Unknown sale ID " + response.getPaymentResponse().getSaleData()
-											.getSaleTransactionID().getTransactionID());
-								}
-								break;
-							}
-
-							Response responseBody = response.getPaymentResponse().getResponse();
-
-							if (responseBody.getResult() != null) {
-								System.out.println(String.format("Payment Result: %s", responseBody.getResult()));
-
-								if (responseBody.getResult() != ResponseResult.Success) {
-									System.out.println(String.format("Error Condition: %s, Additional Response: %s",
-											responseBody.getErrorCondition(), responseBody.getAdditionalResponse()));
-								}
-							}
-
-							waitingForResponse = false;
+						if (!waitingForResponse) {
+							if (responseResult.containsKey("GotValidResponse"))
+								gotValidResponse = responseResult.get("GotValidResponse");
+							else
+								gotValidResponse = false;
 						}
 					}
 				}
 			} catch (ConfigurationException e) {
-				System.out.println(e);
+				log(String.format("ConfigurationException: %s", e.toString()));
 			} catch (NotConnectedException e) {
-				System.out.println(e);
+				log(String.format("NotConnectedException: %s", e.toString()));
 			} finally {
 				displayRequestThread.interrupt();
 			}
-
-			return null;
+			return gotValidResponse;
 		});
 
+		boolean gotValidResponse = false;
 		try {
-			System.out.println(payment.get(60, TimeUnit.SECONDS)); // set timeout
+			gotValidResponse = payment.get(60, TimeUnit.SECONDS); // set timeout
+			if (!gotValidResponse)
+				abortReason = "Timeout";
 		} catch (TimeoutException e) {
 			System.err.println("Payment Request Timeout...");
+			abortReason = "Timeout";
 		} catch (ExecutionException | InterruptedException e) {
-			System.out.println(e);
+			log(String.format("Exception: %s", e.toString()));
+			abortReason = "Other Exception";
 		} finally {
 			executor.shutdownNow();
-			checkTransactionStatus(serviceID);
+			if (!gotValidResponse)
+				checkTransactionStatus(serviceID, abortReason);
 		}
 	}
 
-	private static void checkTransactionStatus(String serviceID) {
-		System.out.println("Sending transaction status request to check status of payment...");
+	private static void handleRequestMessage(SaleToPOI msg) {
+		MessageCategory messageCategory = MessageCategory.Other;
+		if (msg instanceof SaleToPOIRequest) {
+			SaleToPOIRequest request = (SaleToPOIRequest) msg;
+			log(String.format("Request(JSON): %s", request.toJson()));
+			if (request.getMessageHeader() != null)
+				messageCategory = request.getMessageHeader().getMessageCategory();
+			if (messageCategory == MessageCategory.Display) {
+				DisplayRequest displayRequest = request.getDisplayRequest();
+				if (displayRequest != null) {
+					log("Display Output = " + displayRequest.getDisplayText());
+				}
+			} else
+				log(messageCategory + " received during response message handling.");
+		} else
+			log("Unexpected request message received.");
+	}
+
+	private static Map<String, Boolean> handleResponseMessage(SaleToPOIRequest paymentRequest, SaleToPOI msg) {
+		Map<String, Boolean> responseResult = new HashMap<String, Boolean>();
+		MessageCategory messageCategory = MessageCategory.Other;
+		if (msg instanceof SaleToPOIResponse) {
+			SaleToPOIResponse response = (SaleToPOIResponse) msg;
+			log(String.format("Response(JSON): %s", response.toJson()));
+			if (response.getMessageHeader() != null) {
+				messageCategory = response.getMessageHeader().getMessageCategory();
+				log("Message Category: " + messageCategory);
+				switch (messageCategory) {
+					case Event:
+						EventNotification eventNotification = response.getEventNotification();
+						log("Event Details: " + eventNotification.getEventDetails());
+						break;
+					case Payment:
+						if (response.getMessageHeader().getServiceID()
+								.equalsIgnoreCase(paymentRequest.getMessageHeader().getServiceID())) {
+							{
+								Response responseBody = response.getPaymentResponse().getResponse();
+								if (responseBody.getResult() != null) {
+									log(String.format("Payment Result: %s", responseBody.getResult()));
+
+									if (responseBody.getResult() != ResponseResult.Success) {
+										log(String.format("Error Condition: %s, Additional Response: %s",
+												responseBody.getErrorCondition(),
+												responseBody.getAdditionalResponse()));
+									}
+									responseResult.put("GotValidResponse", true);
+								}
+							}
+							responseResult.put("WaitingForAnotherResponse", false);
+						} else {
+							log("Service ID of response message doesn't match the request.");
+						}
+						break;
+					default:
+						log(messageCategory + " received during response message handling.");
+						break;
+				}
+			}
+		} else
+			log("Unexpected response message received.");
+
+		return responseResult;
+	}
+
+	private static void checkTransactionStatus(String serviceID, String abortReason) {
+		log("Sending transaction status request to check status of payment...");
 
 		ExecutorService executor = Executors.newSingleThreadExecutor();
-		Future<Void> transaction = executor.submit(() -> {
+		Future<Boolean> transaction = executor.submit(() -> {
 			SaleToPOIRequest transactionStatusRequest = null;
+			boolean gotValidResponse = false;
 			try {
-				transactionStatusRequest = buildTransactionStatusRequest(serviceID);
 
-				System.out.println("Sending message to websocket server: " + "\n" + transactionStatusRequest);
-				fusionClient.sendMessage(transactionStatusRequest);
+				if (abortReason != "") {
+					SaleToPOIRequest abortTransactionPOIRequest = buildAbortRequest(serviceID, abortReason);
+
+					log("Sending abort message to websocket server: " + "\n" + abortTransactionPOIRequest);
+					fusionClient.sendMessage(abortTransactionPOIRequest);
+				}
+
+				boolean buildAndSendRequestMessage = true;
 
 				boolean waitingForResponse = true;
 
 				while (waitingForResponse) {
+					if (buildAndSendRequestMessage) {
+						transactionStatusRequest = buildTransactionStatusRequest(serviceID);
+
+						log("Sending message to websocket server: " + "\n" + transactionStatusRequest);
+						fusionClient.sendMessage(transactionStatusRequest);
+					}
+					buildAndSendRequestMessage = false;
 					Optional<SaleToPOIResponse> optResponse = Optional
 							.ofNullable(fusionClient.inQueueResponse.poll(1, TimeUnit.SECONDS));
 
 					if (optResponse.isPresent()) {
 						SaleToPOIResponse response = optResponse.get();
-						System.out.println(response.toJson());
+						log(String.format("Response(JSON): %s", response.toJson()));
+						MessageCategory messageCategory = response.getMessageHeader().getMessageCategory();
+						log("Message Category: " + messageCategory);
+						if (messageCategory == MessageCategory.Event) {
+							EventNotification eventNotification = response.getEventNotification();
+							log("Event Details: " + eventNotification.getEventDetails());
+							continue;
+						} else if (messageCategory == MessageCategory.Payment) {
+							log("Disregard Payment response during transaction status checking.");
+							continue;
+						}
 
 						boolean serviceIDMatchesRequest = response.getMessageHeader() != null
 								&& response.getMessageHeader().getServiceID()
 										.equalsIgnoreCase(transactionStatusRequest.getMessageHeader().getServiceID());
-
-						if (serviceIDMatchesRequest && response.getTransactionStatusResponse() != null
+						if (!serviceIDMatchesRequest) {
+							log(String.format("Service ID mismatch.  Expected %s but got %s.",
+									transactionStatusRequest.getMessageHeader().getServiceID(),
+									response.getMessageHeader().getServiceID()));
+						} else if (response.getTransactionStatusResponse() != null
 								&& response.getTransactionStatusResponse().getResponse() != null) {
 							Response responseBody = response.getTransactionStatusResponse().getResponse();
 
 							if (responseBody.getResult() != null) {
-								System.out.println(
+								log(
 										String.format("Transaction Status Result: %s ", responseBody.getResult()));
 
 								if (responseBody.getResult() == ResponseResult.Success) {
@@ -318,25 +409,31 @@ public class FusionClientDemo {
 									}
 
 									if (paymentResponseBody != null) {
-										System.out.println(
-												String.format("Payment Result: %s", paymentResponseBody.getResult()));
+										log(
+												String.format("Actual Payment Result: %s",
+														paymentResponseBody.getResult()));
 
 										if (paymentResponseBody.getErrorCondition() != null
 												|| paymentResponseBody.getAdditionalResponse() != null) {
-											System.out.println(
+											log(
 													String.format("Error Condition: %s, Additional Response: %s",
-															responseBody.getErrorCondition(),
-															responseBody.getAdditionalResponse()));
+															paymentResponseBody.getErrorCondition(),
+															paymentResponseBody.getAdditionalResponse()));
 										}
 									}
+									gotValidResponse = true;
 									waitingForResponse = false;
 
 								} else if (responseBody.getErrorCondition() == ErrorCondition.InProgress) {
-									System.out.println("Payment in progress...");
-									System.out.println(String.format("Error Condition: %s, Additional Response: %s",
+									log("Payment in progress...");
+									log(String.format("Error Condition: %s, Additional Response: %s",
 											responseBody.getErrorCondition(), responseBody.getAdditionalResponse()));
 									Thread.sleep(10000); // wait for 10 seconds before next iteration
+									buildAndSendRequestMessage = true;
 								} else {
+									log(String.format("Error Condition: %s, Additional Response: %s",
+											responseBody.getErrorCondition(), responseBody.getAdditionalResponse()));
+									gotValidResponse = true;
 									waitingForResponse = false;
 								}
 							}
@@ -344,19 +441,18 @@ public class FusionClientDemo {
 					}
 				}
 			} catch (ConfigurationException e) {
-				System.out.println(e);
+				log(String.format("ConfigurationException: %s", e.toString()));
 			} catch (NotConnectedException e) {
-				System.out.println(e);
+				log(String.format("NotConnectedException: %s", e.toString()));
 			}
-			return null;
+			return gotValidResponse;
 		});
-
 		try {
-			System.out.println(transaction.get(60, TimeUnit.SECONDS)); // set timeout
+			transaction.get(90, TimeUnit.SECONDS); // set timeout
 		} catch (TimeoutException e) {
 			System.err.println("Transaction Status Timeout...");
 		} catch (ExecutionException | InterruptedException e) {
-			System.out.println(e);
+			log(String.format("Exception: %s", e.toString()));
 		} finally {
 			executor.shutdownNow();
 		}
@@ -427,7 +523,7 @@ public class FusionClientDemo {
 
 		AmountsReq amountsReq = new AmountsReq.Builder()//
 				.currency("AUD")//
-				.requestedAmount(new BigDecimal(1000.00))//
+				.requestedAmount(new BigDecimal(1.00))//
 				.build();
 
 		SaleItem saleItem = new SaleItem.Builder()//
@@ -488,6 +584,43 @@ public class FusionClientDemo {
 		return saleToPOI;
 	}
 
+	private static SaleToPOIRequest buildAbortRequest(String paymentServiceID, String abortReason)
+			throws ConfigurationException {
+
+		// Message Header
+		MessageHeader messageHeader = new MessageHeader.Builder()//
+				.messageClass(MessageClass.Service)//
+				.messageCategory(MessageCategory.Abort)//
+				.messageType(MessageType.Request)//
+				.serviceID(MessageHeaderUtil.generateServiceID(10))//
+				.saleID(SALE_ID)//
+				.POIID(POI_ID)//
+				.build();
+
+		MessageReference messageReference = new MessageReference.Builder().messageCategory(MessageCategory.Abort)
+				.serviceID(paymentServiceID).build();
+
+		AbortTransactionRequest abortTransactionRequest = new AbortTransactionRequest(messageReference, abortReason);
+
+		SecurityTrailer securityTrailer = null;
+		try {
+			securityTrailer = SecurityTrailerUtil.generateSecurityTrailer(messageHeader, abortTransactionRequest,
+					KEKConfig.getInstance().getValue());
+		} catch (InvalidKeyException | NoSuchPaddingException | InvalidAlgorithmParameterException
+				| NoSuchAlgorithmException | IllegalBlockSizeException | BadPaddingException | InvalidKeySpecException
+				| IOException e) {
+			e.printStackTrace();
+		}
+
+		SaleToPOIRequest saleToPOI = new SaleToPOIRequest.Builder()//
+				.messageHeader(messageHeader)//
+				.request(abortTransactionRequest)//
+				.securityTrailer(securityTrailer)//
+				.build();
+
+		return saleToPOI;
+	}
+
 	private static SaleToPOIRequest buildTransactionStatusRequest(String serviceID) throws ConfigurationException {
 		// Transaction Status Request
 		MessageReference messageReference = new MessageReference.Builder()//
@@ -528,4 +661,7 @@ public class FusionClientDemo {
 		return saleToPOI;
 	}
 
+	private static void log(String logData) {
+		System.out.println(sdf.format(new Timestamp(System.currentTimeMillis())) + " " + logData); // 2021.03.24.16.34.26
+	}
 }


### PR DESCRIPTION
- Logs should include timestamps.
- When processing a payment response, check the Service ID (not the Sale Transaction ID).  If the Service ID doesn’t match the request’s one, wait for the next payment response.
- Only call error recovery handling/transaction status checking either when:
• An error occurred before a valid payment response is received or
• No payment response is received after 60 seconds since the last host message is received from the host.
- Error recovery:
a. Send an AbortRequest.
b. Disregard the PaymentResponse received after sending the AbortRequest.
c. Send a TransactionStatusRequest after sending an AbortRequest.
d. To make sure that the TransactionStatusResponse is for the previous PaymentResponse, verify the ServiceID (not SaleTransactionID) of the PaymentResponse in the RepeatedMessageResponse against the ServiceID of the PaymentRequest.  If they don’t match, log a mismatch error and proceed with waiting again.
e. The whole error recovery handling should only take around 90 seconds.